### PR TITLE
Avoid exception when superclass is null and no docblock is provided for a method

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -284,7 +284,7 @@ class Converter
                         }
 
                         $parentFqsen = $obj->getParent();
-                        if (!$parent = $this->getObject($project, $parentFqsen, self::OBJECT_CLASS)) {
+                        if (null === $parentFqsen || !$parent = $this->getObject($project, $parentFqsen, self::OBJECT_CLASS)) {
                             return;
                         }
 

--- a/tests/Fixtures/Foo.php
+++ b/tests/Fixtures/Foo.php
@@ -7,6 +7,10 @@ namespace bar;
  */
 class Foo
 {
+    public function bar($foo)
+    {
+    }
+
     /**
      * @param float $a
      */

--- a/tests/test.php
+++ b/tests/test.php
@@ -120,6 +120,10 @@ namespace bar;
  */
 class Foo
 {
+    public function bar($foo)
+    {
+    }
+
     /**
      * @param float $a
      */


### PR DESCRIPTION
When a class does not have parent and no docblock is provided for a method, `Class_::getParent()` method returns `null` so an exception is thrown:

```
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to Dunglas\PhpDocToTypeHint\Converter::getObject() must be an instance of phpDocumentor\Reflection\Fqsen, null given, called in /Users/meyerb/workspace/phpdoc-to-typehint/src/Converter.php on line 287 and defined in /Users/meyerb/workspace/phpdoc-to-typehint/src/Converter.php:325
Stack trace:
#0 /Users/meyerb/workspace/phpdoc-to-typehint/src/Converter.php(287): Dunglas\PhpDocToTypeHint\Converter->getObject(Object(phpDocumentor\Reflection\Php\Project), NULL, 0)
#1 /Users/meyerb/workspace/phpdoc-to-typehint/src/Converter.php(425): Dunglas\PhpDocToTypeHint\Converter->getDocBlock(Object(phpDocumentor\Reflection\Php\Project), 0, NULL, 'ElePHPant', '__construct')
#2 /Users/meyerb/workspace/phpdoc-to-typehint/src/Converter.php(105): Dunglas\PhpDocToTypeHint\Converter->getReturn(Object(phpDocumentor\Reflection\Php\Project), 0, NULL, 'ElePHPant', '__construct')
#3 /Users/meyerb/workspace/phpdoc-to-typehint/src/ConvertCommand.php(90): Dunglas\PhpDocToTypeHint\Converter->convert(Obj in /Users/meyerb/workspace/phpdoc-to-typehint/src/Converter.php on line 325
```
