### PR TITLE
converter: preserve new lines when inserting return type declarations

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -105,7 +105,15 @@ class Converter
                             $return = $this->getReturn($project, $objectType, $namespace, $object, $function);
 
                             if ($return && $return[0] && !$return[1]) {
+                                if ($endsInNewLine = $this->endsInNewLine($output)) {
+                                    $output = substr($output, 0, -strlen($endsInNewLine));
+                                }
+
                                 $output .= sprintf(': %s', $return[0]);
+
+                                if ($endsInNewLine) {
+                                    $output .= $endsInNewLine;
+                                }
                             }
 
                             $function = null;
@@ -474,5 +482,27 @@ class Converter
         }
 
         return [$type->__toString(), false];
+    }
+
+    /**
+     * Determines if the string ends in a new line and returns it.
+     *
+     * Will also include additional space/tab character if present, i.e. the
+     * indentation into the next line.
+     *
+     * Returns an empty string if no match was found.
+     *
+     * @param string $output
+     * @return string
+     */
+    private function endsInNewLine(string $output): string
+    {
+        $result = preg_match('/((?:\r\n|\r|\n)[ \t]*)$/', $output, $matches);
+
+        if (0 === $result) {
+            return '';
+        }
+
+        return $matches[1];
     }
 }

--- a/tests/test.php
+++ b/tests/test.php
@@ -57,8 +57,8 @@ function foo()
  *
  * @return float
  */
-function bar(\DateTime $a = null, array $b, int $c = null, string $d, bool $e, callable $f = null)
-: float{
+function bar(\DateTime $a = null, array $b, int $c = null, string $d, bool $e, callable $f = null): float
+{
     return 0.0;
 }
 
@@ -98,8 +98,8 @@ namespace foo;
  *
  * @return int
  */
-function test(string $a = null)
-: int{
+function test(string $a = null): int
+{
 }
 
 PHP
@@ -178,8 +178,8 @@ trait BazTrait
      *
      * @return \DateTime
      */
-    protected function inTrait(int $a)
-    : \DateTime{
+    protected function inTrait(int $a): \DateTime
+    {
     }
 }
 
@@ -210,8 +210,8 @@ class Child extends Foo implements BarInterface
     /**
      * {@inheritdoc}
      */
-    public function baz(array $a, int $b)
-    : float{
+    public function baz(array $a, int $b): float
+    {
     }
 }
 


### PR DESCRIPTION
Will also include additional space/tab characters, i.e. indentation
into the next line.

I found it quite unpleasant that code like:

``` PHP
/**
 * @param string $arg
 */
function foo($arg)
{
}
```

got converted to

``` PHP
/**
 * @param string $arg
 */
function foo($arg)
: string{
}
```

All return type declarations now get converted to:

``` PHP
/**
 * @param string $arg
 */
function foo($arg): string{
}
```

Tests are adapted.
