### PR TITLE
converter: handle params in phpdoc without type declaration

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -447,6 +447,11 @@ class Converter
     {
         $type = $tag->getType();
 
+        if (null === $type) {
+            // No type specified
+            return [];
+        }
+
         if ($type instanceof Compound) {
             if ($type->has(2)) {
                 // Several types, cannot guess

--- a/tests/Fixtures/param_no_type.php
+++ b/tests/Fixtures/param_no_type.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @param $noType
+ */
+function param_no_type($noType)
+{
+}

--- a/tests/test.php
+++ b/tests/test.php
@@ -220,4 +220,21 @@ PHP
     }
 }
 
+$projectFactory = ProjectFactory::createInstance();
+$project = $projectFactory->create('paramNoType', [__DIR__.'/Fixtures/param_no_type.php']);
+
+foreach ($project->getFiles() as $path => $file) {
+    same(<<<'PHP'
+<?php
+/**
+ * @param $noType
+ */
+function param_no_type($noType)
+{
+}
+
+PHP
+        , $converter->convert($project, $file));
+}
+
 echo 'Good job! Everything is fine.'.PHP_EOL;


### PR DESCRIPTION
Otherwise it would crash when calling __toString() on `null`.

Test added.
