### PR TITLE
converter: convert any scalar array declaration to pure array

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\File;
 use phpDocumentor\Reflection\Php\Interface_;
 use phpDocumentor\Reflection\Php\Project;
+use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Null_;
 
@@ -471,6 +472,12 @@ class Converter
 
             // Mixed types, cannot guess
             return [];
+        }
+
+        if ($type instanceof Array_) {
+            // May contain more specific type declarations, but we only
+            // convert to pure arrays
+            return ['array', false];
         }
 
         return [$type->__toString(), false];


### PR DESCRIPTION
Currently, scalar array declarations like `string[]` are literally taken, breaking the PHP code.

E.g.

``` PHP
/**
 * @param string[] $data
 */
function foo($data)
{
}
```

gets converted to

``` PHP
/**
 * @param string[] $data
 */
function foo(string[] $data)
{
}
```

which isn't supported in PHP7. This patch converts it to

``` PHP
/**
 * @param string[] $data
 */
function foo(array $data)
{
}
```

If this is acceptable, I will provide tests too.
