### PR TITLE
converter: apply whitelist filtering on supported types

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -459,10 +459,10 @@ class Converter
     }
 
     /**
-     * Gets the parameter type and applies a whitelist of PHPs supported types
+     * Gets the parameter type and tries to find best-matching PHP type
      *
-     * The whitelist is only applied for all-lowercase character; everything
-     * else is considered to be a class name.
+     * Commonly used type aliases are normalized and a whitelist for
+     * all-lowercase types is applied.
      *
      * @param Tag $tag
      *
@@ -479,6 +479,7 @@ class Converter
         $typeDesc = $type[0];
 
         if ($typeDesc === strtolower($typeDesc)) {
+            $typeDesc = $this->normalizeType($typeDesc);
             // match all-lowercase types against known types
             if (!in_array($typeDesc, static::TYPES)) {
                 return [];
@@ -559,5 +560,36 @@ class Converter
         }
 
         return $matches[1];
+    }
+
+     /**
+     * Normalizes the type.
+     *
+     * @link https://github.com/symfony/symfony/blob/d2d8d17a8068d76f42c42c7791f45ca68f4f98a4/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php#L317-L346
+     * @license https://github.com/symfony/symfony/blob/d2d8d17a8068d76f42c42c7791f45ca68f4f98a4/src/Symfony/Component/PropertyInfo/LICENSE
+     *
+     * @param string $docType
+     *
+     * @return string
+     */
+    private function normalizeType($docType)
+    {
+        switch ($docType) {
+            case 'integer':
+                return 'int';
+
+            case 'boolean':
+                return 'bool';
+
+            // real is not part of the PHPDoc standard, so we ignore it
+            case 'double':
+                return 'float';
+
+            case 'callback':
+                return 'callable';
+
+            default:
+                return $docType;
+        }
     }
 }

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -38,6 +38,19 @@ class Converter
     const OBJECT_FUNCTION = 3;
 
     /**
+     * @link http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
+     */
+    const TYPES = [
+        'array',
+        'bool',
+        'callable',
+        'float',
+        'int',
+        'self',
+        'string',
+    ];
+
+    /**
      * Converts the given file.
      *
      * @param Project $project
@@ -446,13 +459,43 @@ class Converter
     }
 
     /**
-     * Gets the type of the parameter or null if it is not defined.
+     * Gets the parameter type and applies a whitelist of PHPs supported types
+     *
+     * The whitelist is only applied for all-lowercase character; everything
+     * else is considered to be a class name.
      *
      * @param Tag $tag
      *
      * @return array
      */
     private function getType(Tag $tag): array
+    {
+        $type = $this->getTypeFromTag($tag);
+
+        if (!$type) {
+            return $type;
+        }
+
+        $typeDesc = $type[0];
+
+        if ($typeDesc === strtolower($typeDesc)) {
+            // match all-lowercase types against known types
+            if (!in_array($typeDesc, static::TYPES)) {
+                return [];
+            }
+        }
+
+        return $type;
+    }
+
+    /**
+     * Gets the type of the parameter or an empty array if it is not defined.
+     *
+     * @param Tag $tag
+     *
+     * @return array
+     */
+    private function getTypeFromTag(Tag $tag): array
     {
         $type = $tag->getType();
 

--- a/tests/Fixtures/type_aliases_and_whitelisting.php
+++ b/tests/Fixtures/type_aliases_and_whitelisting.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @param integer $integer
+ * @param boolean $boolean
+ * @param real $real
+ * @param double $double
+ * @param callback $callback
+ * @param void $void
+ * @param mixed $mixed
+ * @param unknown $unknown
+ * @param Class $class
+ */
+function aliases($integer, $boolean, $real, $double, $callback, $void, $mixed, $unkown, $class) {
+}

--- a/tests/test.php
+++ b/tests/test.php
@@ -238,7 +238,7 @@ PHP
 }
 
 $projectFactory = ProjectFactory::createInstance();
-$project = $projectFactory->create('paramNoType', [__DIR__.'/Fixtures/array_no_types.php']);
+$project = $projectFactory->create('arrayNoTypes', [__DIR__.'/Fixtures/array_no_types.php']);
 
 foreach ($project->getFiles() as $path => $file) {
     $expected = <<<'PHP'
@@ -251,6 +251,31 @@ foreach ($project->getFiles() as $path => $file) {
  * @return float[]
  */
 function array_no_types(array $ints, array $strings, array $someClasses) : array{
+}
+
+PHP;
+    same($expected, $converter->convert($project, $file));
+}
+
+
+$projectFactory = ProjectFactory::createInstance();
+$project = $projectFactory->create('typeAliasesWhitelisting', [__DIR__.'/Fixtures/type_aliases_and_whitelisting.php']);
+
+foreach ($project->getFiles() as $path => $file) {
+    $expected = <<<'PHP'
+<?php
+/**
+ * @param integer $integer
+ * @param boolean $boolean
+ * @param real $real
+ * @param double $double
+ * @param callback $callback
+ * @param void $void
+ * @param mixed $mixed
+ * @param unknown $unknown
+ * @param Class $class
+ */
+function aliases(int $integer, bool $boolean, $real, float $double, callable $callback, $void, $mixed, $unkown, \Class $class) {
 }
 
 PHP;


### PR DESCRIPTION
Only in effect on all-lowercase types. This is to filter out stuff like
`mixed`, `void`, `$this`, etc.

Currently return type hints like `mixed`, `void` or `$this`, which are quite common, get converted literally into PHP.

`mixed` and `void` are expected to be classes, `$this` isn't an allowed syntax.

The idea of this PR is that, in case the whole type hint is in lowercase, it must be one of the supported type declarations as listed at http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration ; otherwise the type hint gets just ignroed.

This automatically filters out a lot of unsupported stuff.

An edge case is when referring to all-lowercase classes. This PR wouldn't support them.

If this is acceptable, I can provide tests too.
