### PR TITLE
Support function arguments passed by reference

### DIFF
--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -88,6 +88,7 @@ final class ConverterTest extends TestCase
             ['paramNoType', 'param_no_type.php'],
             ['arrayNoTypes', 'array_no_types.php'],
             ['typeAliasesWhitelisting', 'type_aliases_and_whitelisting.php'],
+            ['passByReference', 'pass_by_reference.php'],
         ];
     }
 }

--- a/tests/Fixtures/pass_by_reference.php
+++ b/tests/Fixtures/pass_by_reference.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @param string $a
+ * @param array $b
+ * @param int $c
+ * @return bool
+ */
+function pass_by_reference($a, &$b, int &$c)
+{
+}
+
+$closure = function (&$a) {
+};
+
+function pass_by_reference_undocumented(&$a, $b = 1 & 1)
+{
+}
+
+/**
+ * @param string $a
+ */
+function not_by_reference($a)
+{
+}

--- a/tests/Results/pass_by_reference.php
+++ b/tests/Results/pass_by_reference.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @param string $a
+ * @param array $b
+ * @param int $c
+ * @return bool
+ */
+function pass_by_reference(string $a, array &$b, int &$c): bool
+{
+}
+
+$closure = function (&$a) {
+};
+
+function pass_by_reference_undocumented(&$a, $b = 1 & 1)
+{
+}
+
+/**
+ * @param string $a
+ */
+function not_by_reference(string $a)
+{
+}


### PR DESCRIPTION
Ampersands inside function signatures are not added to the output immediately, instead they are handled later in the code, when the converter may prepend type declarations.

Added test.