### PR TITLE
Support PHP 7.1 nullable types (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Supports:
 * methods of classes and traits
 * method definitions in interfaces
 * PHPDoc inheritance
+* PHP 7.1 nullable types (`--nullable-types` option)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Supports:
 * methods of classes and traits
 * method definitions in interfaces
 * PHPDoc inheritance
-* PHP 7.1 nullable types (`--nullable-types` option)
+* PHP 7.1 nullable types (can be disabled with `--no-nullable-types` option)
 
 ## Credits
 

--- a/src/ConvertCommand.php
+++ b/src/ConvertCommand.php
@@ -55,7 +55,7 @@ class ConvertCommand extends Command
             ->setDescription('Convert files')
             ->addOption('exclude', 'e', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Directories to exclude', ['vendor'])
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Displays diff instead of modifying files')
-            ->addOption('nullable-types', null, InputOption::VALUE_NONE, 'Uses nullable types (PHP 7.1+) instead of `null` default value')
+            ->addOption('no-nullable-types', null, InputOption::VALUE_NONE, 'Uses a default `null` value instead of PHP 7.1 nullable types')
             ->addArgument('input', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Input directories', ['.'])
         ;
     }
@@ -88,7 +88,7 @@ class ConvertCommand extends Command
         $changed = [];
         foreach ($project->getFiles() as $file) {
             $old = $file->getSource();
-            $new = $converter->convert($project, $file, $input->getOption('nullable-types'));
+            $new = $converter->convert($project, $file, !$input->getOption('no-nullable-types'));
 
             if ($new !== $old) {
                 if ($input->getOption('dry-run')) {

--- a/src/ConvertCommand.php
+++ b/src/ConvertCommand.php
@@ -55,6 +55,7 @@ class ConvertCommand extends Command
             ->setDescription('Convert files')
             ->addOption('exclude', 'e', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Directories to exclude', ['vendor'])
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Displays diff instead of modifying files')
+            ->addOption('nullable-types', null, InputOption::VALUE_NONE, 'Uses nullable types (PHP 7.1+) instead of `null` default value')
             ->addArgument('input', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Input directories', ['.'])
         ;
     }
@@ -87,7 +88,7 @@ class ConvertCommand extends Command
         $changed = [];
         foreach ($project->getFiles() as $file) {
             $old = $file->getSource();
-            $new = $converter->convert($project, $file);
+            $new = $converter->convert($project, $file, $input->getOption('nullable-types'));
 
             if ($new !== $old) {
                 if ($input->getOption('dry-run')) {

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -35,7 +35,7 @@ final class ConverterTest extends TestCase
     /**
      * @dataProvider filesProvider
      */
-    public function testSingleFiles(string $projectName, string $fileName)
+    public function testSingleFiles(string $projectName, string $fileName, bool $nullableTypes = null)
     {
         $projectFactory = ProjectFactory::createInstance();
         $project = $projectFactory->create(
@@ -46,7 +46,7 @@ final class ConverterTest extends TestCase
         foreach ($project->getFiles() as $file) {
             $this->assertStringEqualsFile(
                 __DIR__.'/Results/'.$fileName,
-                self::$converter->convert($project, $file)
+                self::$converter->convert($project, $file, $nullableTypes !== null ? $nullableTypes : false)
             );
         }
     }
@@ -68,14 +68,14 @@ final class ConverterTest extends TestCase
             if ($childPath === $path) {
                 $this->assertStringEqualsFile(
                     __DIR__.'/Results/Child.php',
-                    self::$converter->convert($project, $file)
+                    self::$converter->convert($project, $file, false)
                 );
             }
         }
     }
 
     /**
-     * @return string[][]
+     * @return array[]
      */
     public function filesProvider(): array
     {
@@ -90,6 +90,7 @@ final class ConverterTest extends TestCase
             ['arrayNoTypes', 'array_no_types.php'],
             ['typeAliasesWhitelisting', 'type_aliases_and_whitelisting.php'],
             ['passByReference', 'pass_by_reference.php'],
+            ['nullableTypes', 'nullable_types.php', true],
         ];
     }
 }

--- a/tests/Fixtures/nullable_types.php
+++ b/tests/Fixtures/nullable_types.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Must be converted.
+ *
+ * @return string|null
+ */
+function foo()
+{
+}
+
+/**
+ * Must be converted.
+ *
+ * @param \DateTime|null $a
+ * @param int|null       $c
+ * @param string[]|null  $d
+ *
+ * @return float
+ */
+function bar($a, array $b, $c, $d, bool $e, callable $f = null)
+{
+    return 0.0;
+}
+
+/**
+ * Must not be modified (no params defined).
+ */
+function baz($a)
+{
+}
+
+/**
+ * Must be converted.
+ *
+ * @return bool[]|null
+ */
+function bazbaz()
+{
+}
+
+/**
+ * Must not be converted (already using type hints).
+ *
+ * @param int $a
+ *
+ * @return string
+ */
+function bat(int $a): string
+{
+}
+
+/**
+ * Must not be modified (incompatible types).
+ *
+ * @param int|string|null
+ *
+ * @return bool|int|null
+ */
+function foobar($a)
+{
+}
+
+/**
+ * Must not be converted (type hints take precedence over PHPDoc annotations).
+ *
+ * @param int|null $a
+ *
+ * @return string
+ */
+function foobaz(int $a): string
+{
+}
+
+/**
+ * Must not be converted (already using default value).
+ *
+ * @param int|null $a
+ */
+function foobat(int $a = null)
+{
+}

--- a/tests/Results/nullable_types.php
+++ b/tests/Results/nullable_types.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Must be converted.
+ *
+ * @return string|null
+ */
+function foo(): ?string
+{
+}
+
+/**
+ * Must be converted.
+ *
+ * @param \DateTime|null $a
+ * @param int|null       $c
+ * @param string[]|null  $d
+ *
+ * @return float
+ */
+function bar(?\DateTime $a, array $b, ?int $c, ?array $d, bool $e, callable $f = null): float
+{
+    return 0.0;
+}
+
+/**
+ * Must not be modified (no params defined).
+ */
+function baz($a)
+{
+}
+
+/**
+ * Must be converted.
+ *
+ * @return bool[]|null
+ */
+function bazbaz(): ?array
+{
+}
+
+/**
+ * Must not be converted (already using type hints).
+ *
+ * @param int $a
+ *
+ * @return string
+ */
+function bat(int $a): string
+{
+}
+
+/**
+ * Must not be modified (incompatible types).
+ *
+ * @param int|string|null
+ *
+ * @return bool|int|null
+ */
+function foobar($a)
+{
+}
+
+/**
+ * Must not be converted (type hints take precedence over PHPDoc annotations).
+ *
+ * @param int|null $a
+ *
+ * @return string
+ */
+function foobaz(int $a): string
+{
+}
+
+/**
+ * Must not be converted (already using default value).
+ *
+ * @param int|null $a
+ */
+function foobat(int $a = null)
+{
+}


### PR DESCRIPTION
Since PHP 7.1, parameter and return type declarations can be prefixed with a question mark to indicate that the type can also be null:
https://wiki.php.net/rfc/nullable_types

A new command-line option (`--nullable-types`) is added to ensure backwards compatibility.
By default, nullable types in PHPDoc type annotations result in default `null` values being added to function signatures, with the side effect of making functions accept fewer arguments than before.
Enabling the option will allow the converter to use proper nullable types instead.

Added test.